### PR TITLE
Treat commas as breaks in token values, rather than just spaces

### DIFF
--- a/cacheobject/directive.go
+++ b/cacheobject/directive.go
@@ -92,7 +92,7 @@ func parse(value string, cd cacheDirective) error {
 			} else {
 				z := k
 				for z < len(value) {
-					if whitespace(value[z]) {
+					if whitespace(value[z]) || value[z] == ',' {
 						break
 					}
 					z++
@@ -100,7 +100,7 @@ func parse(value string, cd cacheDirective) error {
 				i = z
 
 				result := value[k:z]
-				if result[len(result)-1] == ',' {
+				if result != "" && result[len(result)-1] == ',' {
 					result = result[:len(result)-1]
 				}
 

--- a/cacheobject/directive.go
+++ b/cacheobject/directive.go
@@ -70,7 +70,8 @@ func parse(value string, cd cacheDirective) error {
 			j++
 		}
 
-		token := value[i:j]
+		token := strings.ToLower(value[i:j])
+		tokenHasFields := hasFieldNames(token)
 		/*
 			println("GOT TOKEN:")
 			println("	i -> ", i)
@@ -92,8 +93,14 @@ func parse(value string, cd cacheDirective) error {
 			} else {
 				z := k
 				for z < len(value) {
-					if whitespace(value[z]) || value[z] == ',' {
-						break
+					if tokenHasFields {
+						if whitespace(value[z]) {
+							break
+						}
+					} else {
+						if whitespace(value[z]) || value[z] == ',' {
+							break
+						}
 					}
 					z++
 				}
@@ -434,6 +441,16 @@ func (cd *ResponseCacheDirectives) addToken(token string) error {
 		cd.Extensions = append(cd.Extensions, token)
 	}
 	return err
+}
+
+func hasFieldNames(token string) bool {
+	switch token {
+	case "no-cache":
+		return true
+	case "private":
+		return true
+	}
+	return false
 }
 
 func (cd *ResponseCacheDirectives) addPair(token string, v string) error {

--- a/cacheobject/directive_test.go
+++ b/cacheobject/directive_test.go
@@ -411,3 +411,13 @@ func TestReqMinFreshQuoted(t *testing.T) {
 	require.Equal(t, cd.MaxAge, DeltaSeconds(-1))
 	require.Equal(t, cd.MaxStale, DeltaSeconds(-1))
 }
+
+func TestNoSpacesIssue3(t *testing.T) {
+	cd, err := ParseResponseCacheControl(`no-cache,no-store,max-age=0,must-revalidate`)
+	require.NoError(t, err)
+	require.NotNil(t, cd)
+	require.Equal(t, cd.NoCachePresent, true)
+	require.Equal(t, cd.NoStore, true)
+	require.Equal(t, cd.MaxAge, DeltaSeconds(0))
+	require.Equal(t, cd.MustRevalidate, true)
+}

--- a/cacheobject/directive_test.go
+++ b/cacheobject/directive_test.go
@@ -421,3 +421,15 @@ func TestNoSpacesIssue3(t *testing.T) {
 	require.Equal(t, cd.MaxAge, DeltaSeconds(0))
 	require.Equal(t, cd.MustRevalidate, true)
 }
+
+func TestNoSpacesIssue3PrivateFields(t *testing.T) {
+	cd, err := ParseResponseCacheControl(`no-cache, no-store, private=set-cookie,hello, max-age=0, must-revalidate`)
+	require.NoError(t, err)
+	require.NotNil(t, cd)
+	require.Equal(t, cd.NoCachePresent, true)
+	require.Equal(t, cd.NoStore, true)
+	require.Equal(t, cd.MaxAge, DeltaSeconds(0))
+	require.Equal(t, cd.MustRevalidate, true)
+	require.Equal(t, true, cd.Private["Set-Cookie"])
+	require.Equal(t, true, cd.Private["Hello"])
+}


### PR DESCRIPTION
WIP.

Fixes #3.  

Breaks existing test `TestResPrivateExtension`.  