### PR TITLE
Do not leak implementation errors

### DIFF
--- a/cacheobject/directive.go
+++ b/cacheobject/directive.go
@@ -260,10 +260,19 @@ func (cd *RequestCacheDirectives) addPair(token string, v string) error {
 	switch token {
 	case "max-age":
 		cd.MaxAge, err = parseDeltaSeconds(v)
+		if err != nil {
+			err = ErrMaxAgeDeltaSeconds
+		}
 	case "max-stale":
 		cd.MaxStale, err = parseDeltaSeconds(v)
+		if err != nil {
+			err = ErrMaxStaleDeltaSeconds
+		}
 	case "min-fresh":
 		cd.MinFresh, err = parseDeltaSeconds(v)
+		if err != nil {
+			err = ErrMinFreshDeltaSeconds
+		}
 	case "no-cache":
 		err = ErrNoCacheNoArgs
 	case "no-store":

--- a/cacheobject/directive_test.go
+++ b/cacheobject/directive_test.go
@@ -22,7 +22,6 @@ import (
 
 	"fmt"
 	"math"
-	"strconv"
 	"testing"
 )
 
@@ -346,16 +345,15 @@ func TestReqMinFreshBroken(t *testing.T) {
 	require.Nil(t, cd)
 }
 
-func TestReqMinFreshJumk(t *testing.T) {
+func TestReqMinFreshJunk(t *testing.T) {
 	cd, err := ParseRequestCacheControl(`min-fresh=a99a`)
-	require.Error(t, err)
-	// need a struct cast in require... nothing exists?
-	// require.Implements(t, (*strconv.NumError)(nil), err)
-	if numError, ok := err.(*strconv.NumError); ok {
-		require.Equal(t, strconv.ErrSyntax, numError.Err)
-	} else {
-		require.True(t, ok, "Error was not a *strconv.NumError")
-	}
+	require.Equal(t, ErrMinFreshDeltaSeconds, err)
+	require.Nil(t, cd)
+}
+
+func TestReqMinFreshBadValue(t *testing.T) {
+	cd, err := ParseRequestCacheControl(`min-fresh=-1`)
+	require.Equal(t, ErrMinFreshDeltaSeconds, err)
 	require.Nil(t, cd)
 }
 


### PR DESCRIPTION
HTTP requests are bound to have values not conforming to the RFC spec. When that happens it's easier to handle errors when we know it's a bad value in a particular part of Cache-Control header (like with `ErrMaxDeltaSeconds`) than `strconv.ErrSyntax` that appeared somewhere during parsing.