### PR TITLE
Gracefully handle bad values in Expires header

### DIFF
--- a/cacheobject/object.go
+++ b/cacheobject/object.go
@@ -269,7 +269,9 @@ func UsingRequestResponse(req *http.Request,
 	if respHeaders.Get("Expires") != "" {
 		expiresHeader, err = http.ParseTime(respHeaders.Get("Expires"))
 		if err != nil {
-			return nil, time.Time{}, err
+			// sometimes servers will return `Expires: 0` or `Expires: -1` to
+			// indicate expired content
+			expiresHeader = time.Time{}
 		}
 		expiresHeader = expiresHeader.UTC()
 	}

--- a/cacheobject/object_http_test.go
+++ b/cacheobject/object_http_test.go
@@ -75,3 +75,17 @@ func TestCachableResponseNoHeaders(t *testing.T) {
 	require.Len(t, reasons, 0)
 	require.True(t, expires.IsZero())
 }
+
+func TestCachableResponseBadExpires(t *testing.T) {
+	req, res := roundTrip(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Expires", "-1")
+		fmt.Fprintln(w, `{}`)
+	})
+
+	reasons, expires, err := UsingRequestResponse(req, res.StatusCode, res.Header, false)
+
+	require.NoError(t, err)
+	require.Len(t, reasons, 0)
+	require.True(t, expires.IsZero())
+}


### PR DESCRIPTION
Looking at RFC7234 (https://tools.ietf.org/html/rfc7234#section-5.3):

  > A cache recipient MUST interpret invalid date formats, especially
  > the value "0", as representing a time in the past (i.e., "already
  > expired").

This change sets Expires header to "zero" time for any invalid date
input.