### PR TITLE
cacheobject: experimental stale and immutable response directives

### DIFF
--- a/cacheobject/directive_test.go
+++ b/cacheobject/directive_test.go
@@ -246,6 +246,27 @@ func TestResPrivate(t *testing.T) {
 	require.Equal(t, cd.PrivatePresent, true)
 }
 
+func TestResImmutable(t *testing.T) {
+	cd, err := ParseResponseCacheControl(`immutable`)
+	require.NoError(t, err)
+	require.NotNil(t, cd)
+	require.Equal(t, cd.Immutable, true)
+}
+
+func TestResStaleIfError(t *testing.T) {
+	cd, err := ParseResponseCacheControl(`stale-if-error=99999`)
+	require.NoError(t, err)
+	require.NotNil(t, cd)
+	require.Equal(t, cd.StaleIfError, DeltaSeconds(99999))
+}
+
+func TestResStaleWhileRevalidate(t *testing.T) {
+	cd, err := ParseResponseCacheControl(`stale-while-revalidate=99999`)
+	require.NoError(t, err)
+	require.NotNil(t, cd)
+	require.Equal(t, cd.StaleWhileRevalidate, DeltaSeconds(99999))
+}
+
 func TestParseDeltaSecondsZero(t *testing.T) {
 	ds, err := parseDeltaSeconds("0")
 	require.NoError(t, err)


### PR DESCRIPTION
- Support parsing response directives with:
    - `immutable`
    - `stale-if-error`
    - `stale-while-revalidate`

These directives are supported by some CDNs (e.g: Fastly) and can be useful in proxies.

## More info

You can read more about them here:
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Extension_Cache-Control_directives
- https://www.fastly.com/blog/stale-while-revalidate-stale-if-error-available-today
