### PR TITLE
Tests: Explicit cast of MaxInt64 to int64.  

### DIFF
--- a/cacheobject/directive_test.go
+++ b/cacheobject/directive_test.go
@@ -280,7 +280,7 @@ func TestParseDeltaSecondsLarge(t *testing.T) {
 }
 
 func TestParseDeltaSecondsVeryLarge(t *testing.T) {
-	ds, err := parseDeltaSeconds(fmt.Sprintf("%d", math.MaxInt64))
+	ds, err := parseDeltaSeconds(fmt.Sprintf("%d", int64(math.MaxInt64)))
 	require.NoError(t, err)
 	require.Equal(t, ds, DeltaSeconds(math.MaxInt32))
 }


### PR DESCRIPTION
This feels a little weird, in that i'm using `math.MaxInt64`, and since its a constant, its kinda, expanded there, but only to an `int` type, which it overflows.

The blog post here explains how this works: https://blog.golang.org/constants

Upstream issue for stdlib was raised here: https://github.com/golang/go/issues/23086

Fixes #12
