### PR TITLE
Handle empty `max-stale` directive

### DIFF
--- a/cacheobject/directive.go
+++ b/cacheobject/directive.go
@@ -32,7 +32,7 @@ var (
 	ErrQuoteMismatch         = errors.New("Missing closing quote")
 	ErrMaxAgeDeltaSeconds    = errors.New("Failed to parse delta-seconds in `max-age`")
 	ErrSMaxAgeDeltaSeconds   = errors.New("Failed to parse delta-seconds in `s-maxage`")
-	ErrMaxStaleDeltaSeconds  = errors.New("Failed to parse delta-seconds in `min-fresh`")
+	ErrMaxStaleDeltaSeconds  = errors.New("Failed to parse delta-seconds in `max-stale`")
 	ErrMinFreshDeltaSeconds  = errors.New("Failed to parse delta-seconds in `min-fresh`")
 	ErrNoCacheNoArgs         = errors.New("Unexpected argument to `no-cache`")
 	ErrNoStoreNoArgs         = errors.New("Unexpected argument to `no-store`")
@@ -164,7 +164,7 @@ type cacheDirective interface {
 	addPair(s string, v string) error
 }
 
-// LOW LEVEL API: Repersentation of possible request directives in a `Cache-Control` header: http://tools.ietf.org/html/rfc7234#section-5.2.1
+// LOW LEVEL API: Representation of possible request directives in a `Cache-Control` header: http://tools.ietf.org/html/rfc7234#section-5.2.1
 //
 // Note: Many fields will be `nil` in practice.
 //
@@ -189,6 +189,7 @@ type RequestCacheDirectives struct {
 	// assigned to max-stale, then the client is willing to accept a stale
 	// response of any age.
 	MaxStale DeltaSeconds
+	MaxStaleSet bool
 
 	// min-fresh(delta seconds): http://tools.ietf.org/html/rfc7234#section-5.2.1.3
 	//
@@ -240,10 +241,10 @@ func (cd *RequestCacheDirectives) addToken(token string) error {
 	switch token {
 	case "max-age":
 		err = ErrMaxAgeDeltaSeconds
-	case "max-stale":
-		err = ErrMaxStaleDeltaSeconds
 	case "min-fresh":
 		err = ErrMinFreshDeltaSeconds
+	case "max-stale":
+		cd.MaxStaleSet = true
 	case "no-cache":
 		cd.NoCache = true
 	case "no-store":

--- a/cacheobject/directive_test.go
+++ b/cacheobject/directive_test.go
@@ -328,7 +328,15 @@ func TestReqMaxAge(t *testing.T) {
 }
 
 func TestReqMaxStale(t *testing.T) {
-	cd, err := ParseRequestCacheControl(`max-stale=99999`)
+	cd, err := ParseRequestCacheControl(`max-stale`)
+	require.NoError(t, err)
+	require.NotNil(t, cd)
+	require.True(t, cd.MaxStaleSet)
+	require.Equal(t, cd.MaxStale, DeltaSeconds(-1))
+	require.Equal(t, cd.MaxAge, DeltaSeconds(-1))
+	require.Equal(t, cd.MinFresh, DeltaSeconds(-1))
+
+	cd, err = ParseRequestCacheControl(`max-stale=99999`)
 	require.NoError(t, err)
 	require.NotNil(t, cd)
 	require.Equal(t, cd.MaxStale, DeltaSeconds(99999))
@@ -340,13 +348,6 @@ func TestReqMaxAgeBroken(t *testing.T) {
 	cd, err := ParseRequestCacheControl(`max-age`)
 	require.Error(t, err)
 	require.Equal(t, ErrMaxAgeDeltaSeconds, err)
-	require.Nil(t, cd)
-}
-
-func TestReqMaxStaleBroken(t *testing.T) {
-	cd, err := ParseRequestCacheControl(`max-stale`)
-	require.Error(t, err)
-	require.Equal(t, ErrMaxStaleDeltaSeconds, err)
 	require.Nil(t, cd)
 }
 


### PR DESCRIPTION
This pull request introduces a new field `MaxStaleSet` in the `RequestCacheDirectives` to know if the `max-stale` directive has been set with no value, like specified in the [RFC](https://tools.ietf.org/html/rfc7234#section-5.2.1.2):

```
If no value is assigned to max-stale, then the client is willing to accept a stale response of any age.
```