### PR TITLE
fix!: typos

### DIFF
--- a/api.go
+++ b/api.go
@@ -25,7 +25,7 @@ import (
 )
 
 type Options struct {
-	// Set to True for a prviate cache, which is not shared amoung users (eg, in a browser)
+	// Set to True for a private cache, which is not shared among users (eg, in a browser)
 	// Set to False for a "shared" cache, which is more common in a server context.
 	PrivateCache bool
 }

--- a/cacheobject/directive_test.go
+++ b/cacheobject/directive_test.go
@@ -30,7 +30,7 @@ func TestMaxAge(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cd.MaxAge, DeltaSeconds(-1))
 
-	cd, err = ParseResponseCacheControl("max-age")
+	_, err = ParseResponseCacheControl("max-age")
 	require.Error(t, err)
 
 	cd, err = ParseResponseCacheControl("max-age=20")
@@ -41,7 +41,7 @@ func TestMaxAge(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cd.MaxAge, DeltaSeconds(0))
 
-	cd, err = ParseResponseCacheControl("max-age=-1")
+	_, err = ParseResponseCacheControl("max-age=-1")
 	require.Error(t, err)
 }
 
@@ -50,7 +50,7 @@ func TestSMaxAge(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cd.SMaxAge, DeltaSeconds(-1))
 
-	cd, err = ParseResponseCacheControl("s-maxage")
+	_, err = ParseResponseCacheControl("s-maxage")
 	require.Error(t, err)
 
 	cd, err = ParseResponseCacheControl("s-maxage=20")
@@ -61,7 +61,7 @@ func TestSMaxAge(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cd.SMaxAge, DeltaSeconds(0))
 
-	cd, err = ParseResponseCacheControl("s-maxage=-1")
+	_, err = ParseResponseCacheControl("s-maxage=-1")
 	require.Error(t, err)
 }
 

--- a/cacheobject/object.go
+++ b/cacheobject/object.go
@@ -22,7 +22,7 @@ import (
 	"time"
 )
 
-// LOW LEVEL API: Repersents a potentially cachable HTTP object.
+// LOW LEVEL API: Represents a potentially cachable HTTP object.
 //
 // This struct is designed to be serialized efficiently, so in a high
 // performance caching server, things like Date-Strings don't need to be
@@ -44,7 +44,7 @@ type Object struct {
 	NowUTC time.Time
 }
 
-// LOW LEVEL API: Repersents the results of examinig an Object with
+// LOW LEVEL API: Represents the results of examining an Object with
 // CachableObject and ExpirationObject.
 //
 // TODO(pquerna): decide if this is a good idea or bad
@@ -103,7 +103,7 @@ func CachableObject(obj *Object, rv *ObjectResults) {
 	// To my knowledge, none of them are cachable. Please open a ticket if this is not the case!
 	//
 	default:
-		rv.OutReasons = append(rv.OutReasons, ReasonRequestMethodUnkown)
+		rv.OutReasons = append(rv.OutReasons, ReasonRequestMethodUnknown)
 	}
 
 	if obj.ReqDirectives != nil && obj.ReqDirectives.NoStore {
@@ -232,7 +232,7 @@ func ExpirationObject(obj *Object, rv *ObjectResults) {
 			println("Expiration: ", expiresTime.String())
 		}
 	} else {
-		// TODO(pquerna): what should the default behavoir be for expiration time?
+		// TODO(pquerna): what should the default behavior be for expiration time?
 	}
 
 	rv.OutExpirationTime = expiresTime

--- a/cacheobject/object_test.go
+++ b/cacheobject/object_test.go
@@ -104,7 +104,7 @@ func TestUncachableMethods(t *testing.T) {
 		{"OPTIONS", ReasonRequestMethodOPTIONS},
 		{"CONNECT", ReasonRequestMethodCONNECT},
 		{"TRACE", ReasonRequestMethodTRACE},
-		{"MADEUP", ReasonRequestMethodUnkown},
+		{"MADEUP", ReasonRequestMethodUnknown},
 	}
 
 	for _, mp := range tc {

--- a/cacheobject/reasons.go
+++ b/cacheobject/reasons.go
@@ -45,7 +45,7 @@ const (
 	ReasonRequestMethodTRACE
 
 	// The request method was not recognized by cachecontrol, and should not be cached.
-	ReasonRequestMethodUnkown
+	ReasonRequestMethodUnknown
 
 	// The request included an Cache-Control: no-store header
 	ReasonRequestNoStore
@@ -77,7 +77,7 @@ func (r Reason) String() string {
 		return "ReasonRequestMethodOPTIONS"
 	case ReasonRequestMethodTRACE:
 		return "ReasonRequestMethodTRACE"
-	case ReasonRequestMethodUnkown:
+	case ReasonRequestMethodUnknown:
 		return "ReasonRequestMethodUnkown"
 	case ReasonRequestNoStore:
 		return "ReasonRequestNoStore"


### PR DESCRIPTION
Fix some typos.
The change in `ReasonRequestMethodUnknown` is a BC break.

Also, "cachable" is more often written "cacheable", maybe should we change this too, but it's a bigger BC break.
