### PR TITLE
feat: allow to check if a response is cacheable

### DIFF
--- a/cacheobject/object.go
+++ b/cacheobject/object.go
@@ -110,7 +110,7 @@ func CachableResponseObject(obj *Object, rv *ObjectResults) {
 	  Content-Location header field that has the same value as the POST's
 	  effective request URI (Section 3.1.4.2).
 	*/
-	if obj.ReqMethod == "POST" && !hasFreshness(obj.RespDirectives, obj.RespHeaders, obj.RespExpiresHeader, obj.CacheIsPrivate) {
+	if obj.ReqMethod == http.MethodPost && !hasFreshness(obj.RespDirectives, obj.RespHeaders, obj.RespExpiresHeader, obj.CacheIsPrivate) {
 		rv.OutReasons = append(rv.OutReasons, ReasonRequestMethodPOST)
 	}
 

--- a/cacheobject/object.go
+++ b/cacheobject/object.go
@@ -55,33 +55,17 @@ type ObjectResults struct {
 	OutErr            error
 }
 
-// LOW LEVEL API: Check if a object is cachable.
-func CachableObject(obj *Object, rv *ObjectResults) {
-	rv.OutReasons = nil
-	rv.OutWarnings = nil
-	rv.OutErr = nil
-
+// LOW LEVEL API: Check if a request is cacheable.
+// This function doesn't reset the passed ObjectResults.
+func CachableRequestObject(obj *Object, rv *ObjectResults) {
 	switch obj.ReqMethod {
 	case "GET":
 		break
 	case "HEAD":
 		break
 	case "POST":
-		/**
-		  POST: http://tools.ietf.org/html/rfc7231#section-4.3.3
-
-		  Responses to POST requests are only cacheable when they include
-		  explicit freshness information (see Section 4.2.1 of [RFC7234]).
-		  However, POST caching is not widely implemented.  For cases where an
-		  origin server wishes the client to be able to cache the result of a
-		  POST in a way that can be reused by a later GET, the origin server
-		  MAY send a 200 (OK) response containing the result and a
-		  Content-Location header field that has the same value as the POST's
-		  effective request URI (Section 3.1.4.2).
-		*/
-		if !hasFreshness(obj.ReqDirectives, obj.RespDirectives, obj.RespHeaders, obj.RespExpiresHeader, obj.CacheIsPrivate) {
-			rv.OutReasons = append(rv.OutReasons, ReasonRequestMethodPOST)
-		}
+		// Responses to POST requests can be cacheable if they include explicit freshness information
+		break
 
 	case "PUT":
 		rv.OutReasons = append(rv.OutReasons, ReasonRequestMethodPUT)
@@ -109,10 +93,29 @@ func CachableObject(obj *Object, rv *ObjectResults) {
 	if obj.ReqDirectives != nil && obj.ReqDirectives.NoStore {
 		rv.OutReasons = append(rv.OutReasons, ReasonRequestNoStore)
 	}
+}
+
+// LOW LEVEL API: Check if a response is cacheable.
+// This function doesn't reset the passed ObjectResults.
+func CachableResponseObject(obj *Object, rv *ObjectResults) {
+	/**
+	  POST: http://tools.ietf.org/html/rfc7231#section-4.3.3
+
+	  Responses to POST requests are only cacheable when they include
+	  explicit freshness information (see Section 4.2.1 of [RFC7234]).
+	  However, POST caching is not widely implemented.  For cases where an
+	  origin server wishes the client to be able to cache the result of a
+	  POST in a way that can be reused by a later GET, the origin server
+	  MAY send a 200 (OK) response containing the result and a
+	  Content-Location header field that has the same value as the POST's
+	  effective request URI (Section 3.1.4.2).
+	*/
+	if obj.ReqMethod == "POST" && !hasFreshness(obj.RespDirectives, obj.RespHeaders, obj.RespExpiresHeader, obj.CacheIsPrivate) {
+		rv.OutReasons = append(rv.OutReasons, ReasonRequestMethodPOST)
+	}
 
 	// Storing Responses to Authenticated Requests: http://tools.ietf.org/html/rfc7234#section-3.2
-	authz := obj.ReqHeaders.Get("Authorization")
-	if authz != "" {
+	if obj.ReqHeaders.Get("Authorization") != "" {
 		if obj.RespDirectives.MustRevalidate ||
 			obj.RespDirectives.Public ||
 			obj.RespDirectives.SMaxAge != -1 {
@@ -149,18 +152,26 @@ func CachableObject(obj *Object, rv *ObjectResults) {
 	     *  contains a public response directive (see Section 5.2.2.5).
 	*/
 
-	expires := obj.RespHeaders.Get("Expires") != ""
-	statusCachable := cachableStatusCode(obj.RespStatusCode)
-
-	if expires ||
+	if obj.RespHeaders.Get("Expires") != "" ||
 		obj.RespDirectives.MaxAge != -1 ||
 		(obj.RespDirectives.SMaxAge != -1 && !obj.CacheIsPrivate) ||
-		statusCachable ||
+		cachableStatusCode(obj.RespStatusCode) ||
 		obj.RespDirectives.Public {
 		/* cachable by default, at least one of the above conditions was true */
-	} else {
-		rv.OutReasons = append(rv.OutReasons, ReasonResponseUncachableByDefault)
+		return
 	}
+
+	rv.OutReasons = append(rv.OutReasons, ReasonResponseUncachableByDefault)
+}
+
+// LOW LEVEL API: Check if a object is cachable.
+func CachableObject(obj *Object, rv *ObjectResults) {
+	rv.OutReasons = nil
+	rv.OutWarnings = nil
+	rv.OutErr = nil
+
+	CachableRequestObject(obj, rv)
+	CachableResponseObject(obj, rv)
 }
 
 var twentyFourHours = time.Duration(24 * time.Hour)
@@ -333,7 +344,7 @@ func UsingRequestResponseWithObject(req *http.Request,
 }
 
 // calculate if a freshness directive is present: http://tools.ietf.org/html/rfc7234#section-4.2.1
-func hasFreshness(reqDir *RequestCacheDirectives, respDir *ResponseCacheDirectives, respHeaders http.Header, respExpires time.Time, privateCache bool) bool {
+func hasFreshness(respDir *ResponseCacheDirectives, respHeaders http.Header, respExpires time.Time, privateCache bool) bool {
 	if !privateCache && respDir.SMaxAge != -1 {
 		return true
 	}


### PR DESCRIPTION
I'm working on a cache module for Caddy server, and I need to check if the request will not be cacheable to prevent initializing some useless stuff. What do you think about allowing to do this with the library?