### PR TITLE
Allow stale-while-revalidate and stale-if-error without value to parse successfully

### DIFF
--- a/cacheobject/directive.go
+++ b/cacheobject/directive.go
@@ -481,8 +481,6 @@ func (cd *ResponseCacheDirectives) addToken(token string) error {
 		cd.Immutable = true
 	case "stale-if-error":
 		err = ErrMaxAgeDeltaSeconds
-	case "stale-while-revalidate":
-		err = ErrMaxAgeDeltaSeconds
 	default:
 		cd.Extensions = append(cd.Extensions, token)
 	}

--- a/cacheobject/directive.go
+++ b/cacheobject/directive.go
@@ -479,8 +479,6 @@ func (cd *ResponseCacheDirectives) addToken(token string) error {
 	// Experimental
 	case "immutable":
 		cd.Immutable = true
-	case "stale-if-error":
-		err = ErrMaxAgeDeltaSeconds
 	default:
 		cd.Extensions = append(cd.Extensions, token)
 	}

--- a/cacheobject/directive_test.go
+++ b/cacheobject/directive_test.go
@@ -18,6 +18,7 @@
 package cacheobject
 
 import (
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"fmt"
@@ -265,6 +266,16 @@ func TestResStaleWhileRevalidate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cd)
 	require.Equal(t, cd.StaleWhileRevalidate, DeltaSeconds(99999))
+}
+
+func TestResStaleWhileRevalidateBare(t *testing.T) {
+	cd, err := ParseResponseCacheControl(`stale-while-revalidate`)
+	require.NoError(t, err)
+	require.NotNil(t, cd)
+
+	// bare `stale-while-revalidate` is treated like an extension directive
+	require.EqualValues(t, cd.StaleWhileRevalidate, -1)
+	assert.Contains(t, cd.Extensions, "stale-while-revalidate")
 }
 
 func TestParseDeltaSecondsZero(t *testing.T) {

--- a/cacheobject/directive_test.go
+++ b/cacheobject/directive_test.go
@@ -261,6 +261,16 @@ func TestResStaleIfError(t *testing.T) {
 	require.Equal(t, cd.StaleIfError, DeltaSeconds(99999))
 }
 
+func TestResStaleIfErrorBare(t *testing.T) {
+	cd, err := ParseResponseCacheControl(`stale-if-error`)
+	require.NoError(t, err)
+	require.NotNil(t, cd)
+
+	// `stale-if-error` without value is treated like an extension directive
+	require.Equal(t, cd.StaleIfError, -1)
+	assert.Contains(t, cd.Extensions, "stale-if-error")
+}
+
 func TestResStaleWhileRevalidate(t *testing.T) {
 	cd, err := ParseResponseCacheControl(`stale-while-revalidate=99999`)
 	require.NoError(t, err)


### PR DESCRIPTION
Even though per the spec, both directives require to have a value, returning an error when parsing seems a little strict. It would be great if it was possible to allow this case and just treat it like an extension that people can decide to handle if they want to.

In our concrete example we're trying to increase compatibility with NextJS, who seems to sometimes send this without a value: https://github.com/vercel/vercel/discussions/7882 - we're using `ParseResponseCacheControl` directly, not the higher-level abstractions in this library.

I hope since support for these directives is experimental you're ok with breaking the behaviour for invalid values here.